### PR TITLE
Add travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ matrix:
+  - DB=pgsql MOODLE_BRANCH=master
+  - DB=mysqli MOODLE_BRANCH=master
+  - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
+
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci add-plugin vfremaux/moodle-block_use_stats
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat


### PR DESCRIPTION
here's a pull request that might help you see how travis works.
first go to: http://travis-ci.org/vfremaux and enable travis on the repos you want to use it. (I tend to hit the settings button and configure the repos to only build when .travis.yml is present to avoid some of the errors with older branches that don't have it etc.)

then merge this pull request (or add your own file/generate a new commit on the repo) - the checks will only trigger on each new commit (but it will also run if someone sends you a pull request as well.)

I have already enabled my local fork to use travis - you can see the report it generates here:
https://travis-ci.org/danmarsden/moodle-availability_coursetime/builds/162127326

The build file I've written here will run builds for PHP 7 and php 5.6, postgres and mysql, master, 3.1 and 3.0 branches - you can edit this to add other moodle branches, or remove tests you don't need.

I have also added a line to this file which will also add the block that this plugin depends on before running the tests.

I've found integrating travis with my repos has saved a lot of time - especially on repos that include tests or when community members file pull requests - as travis triggers automatically and gives details on if the new pull request complies or not.

hopefully you find it useful! 
